### PR TITLE
Expand HTML export in RecipeCard

### DIFF
--- a/src/components/RecipeCard.jsx
+++ b/src/components/RecipeCard.jsx
@@ -22,8 +22,8 @@ function RecipeCard({ recipe }) {
     const ingredientsHtml = recipe.ingredients
       .map((ing) => {
         const hasAmount = ing.amount !== undefined && ing.amount !== null && ing.amount !== '';
-        const amount = hasAmount ? `${ing.amount} ${ing.unit}`.trim() : ing.unit;
-        return `<li>${hasAmount ? amount + ' ' : ''}${ing.name}</li>`;
+        const amount = hasAmount ? Number(ing.amount) * scaleFactor : null;
+        return `<li>${hasAmount ? `${amount} ${ing.unit}` : ing.unit} ${ing.name}</li>`;
       })
       .join('');
 
@@ -31,9 +31,22 @@ function RecipeCard({ recipe }) {
       .map((step) => `<li>${step}</li>`)
       .join('');
 
-    const fullHtml = `<h1>${recipe.title}</h1><ul>${ingredientsHtml}</ul><ol>${instructionsHtml}</ol><details><summary>Waarom kersenhout?</summary><p>${recipe.woodExplanation}</p></details>`;
+    const fullHtml = `
+      <h1>${recipe.title}</h1>
+      <p>Voorbereiding: ${recipe.prepTime}</p>
+      <p>Bereiding: ${recipe.cookTime}</p>
+      <p>Gang: ${recipe.course}</p>
+      <p>Keuken: ${recipe.cuisine}</p>
+      <p>Porties: ${recipe.servings * scaleFactor}</p>
+      <h2>Ingrediënten</h2>
+      <ul>${ingredientsHtml}</ul>
+      <h2>Bereiding</h2>
+      <ol>${instructionsHtml}</ol>
+      <details><summary>Waarom kersenhout?</summary><p>${recipe.woodExplanation}</p></details>
+      <div class="note">${recipe.notes}</div>
+    `;
 
-    setHtmlString(fullHtml);
+    setHtmlString(fullHtml.trim());
   };
 
   return (


### PR DESCRIPTION
## Summary
- generate a full HTML recipe card when pressing **Genereer HTML**
- include metadata, ingredient list, instructions, wood explanation and notes in the export

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee7d437f48326939efbacf6d2c6f8