### PR TITLE
Add HTML generator for recipe card

### DIFF
--- a/src/components/RecipeCard.jsx
+++ b/src/components/RecipeCard.jsx
@@ -31,20 +31,76 @@ function RecipeCard({ recipe }) {
       .map((step) => `<li>${step}</li>`)
       .join('');
 
+    const portionButtonsHtml = [1, 2, 3]
+      .map((factor) => {
+        const active = scaleFactor === factor ? 'bg-gray-300' : '';
+        return `<button class="px-2 py-1 border rounded mx-1 ${active}">${factor}x</button>`;
+      })
+      .join('');
+
     const fullHtml = `
-      <h1>${recipe.title}</h1>
-      <p>Voorbereiding: ${recipe.prepTime}</p>
-      <p>Bereiding: ${recipe.cookTime}</p>
-      <p>Gang: ${recipe.course}</p>
-      <p>Keuken: ${recipe.cuisine}</p>
-      <p>Porties: ${recipe.servings * scaleFactor}</p>
-      <h2>Ingrediënten</h2>
-      <ul>${ingredientsHtml}</ul>
-      <h2>Bereiding</h2>
-      <ol>${instructionsHtml}</ol>
-      <details><summary>Waarom kersenhout?</summary><p>${recipe.woodExplanation}</p></details>
-      <div class="note">${recipe.notes}</div>
-    `;
+<div class="bg-white shadow-lg p-6 rounded-md">
+  <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center">
+    <div>
+      <h1 class="text-2xl font-bold">${recipe.title}</h1>
+      <h2 class="italic text-gray-600">\u2013 The Dutch Smokehouse \u2013</h2>
+    </div>
+    <img src="${recipe.image}" alt="${recipe.title}" class="w-40 h-auto mt-4 sm:mt-0" />
+  </div>
+
+  <div class="mt-4 flex flex-wrap gap-2">
+    <button class="bg-yellow-500 text-white px-4 py-2 rounded">Recept afdrukken</button>
+    <button class="border px-4 py-2 rounded">Pin recept</button>
+  </div>
+
+  <div class="mt-4 grid grid-cols-2 sm:grid-cols-5 gap-y-2 text-sm">
+    <div><span class="icon icon-prep inline w-4 h-4 mr-1"></span> Voorbereiding: ${recipe.prepTime}</div>
+    <div><span class="icon icon-cook inline w-4 h-4 mr-1"></span> Bereiding: ${recipe.cookTime}</div>
+    <div><span class="icon icon-course inline w-4 h-4 mr-1"></span> Gang: ${recipe.course}</div>
+    <div><span class="icon icon-cuisine inline w-4 h-4 mr-1"></span> Keuken: ${recipe.cuisine}</div>
+    <div><span class="icon icon-servings inline w-4 h-4 mr-1"></span> Porties: ${recipe.servings * scaleFactor} personen</div>
+  </div>
+
+  <div class="mt-4">${portionButtonsHtml}</div>
+
+  <h2 class="text-xl font-semibold mt-6 mb-2">Ingredi\u00ebnten</h2>
+  <ul class="list-disc list-inside">
+    ${ingredientsHtml}
+  </ul>
+
+  <h2 class="text-xl font-semibold mt-6 mb-2">Bereiding</h2>
+  <ol class="list-decimal list-inside space-y-2">
+    ${instructionsHtml}
+  </ol>
+
+  <div class="mt-6 border rounded p-4 bg-gray-50">
+    <h3 class="font-semibold mb-2">Notities</h3>
+    <p>${recipe.notes}</p>
+  </div>
+
+  <details class="mt-6">
+    <summary class="cursor-pointer font-semibold">Waarom kersenhout?</summary>
+    <p class="mt-2">${recipe.woodExplanation}</p>
+  </details>
+
+  <div class="mt-8 border-t pt-6">
+    <p class="text-gray-700 mb-4">
+      Deze zalm op kersenhout is perfect voor een zomerse avond, met een lichtzoete rooksmaak.
+      Maak het jezelf makkelijk en bestel de benodigdheden direct uit onze webshop.
+    </p>
+
+    <div class="space-y-2">
+      <div>
+        <span class="icon icon-cart inline w-5 h-5 mr-2 text-gray-700"></span>
+        <a href="/product/kersenhout" class="text-blue-600 underline">Kersenhout chunks voor zalm</a>
+      </div>
+      <div>
+        <span class="icon icon-cart inline w-5 h-5 mr-2 text-gray-700"></span>
+        <a href="/product/houten-rookplank" class="text-blue-600 underline">Rookplank voor visgerechten</a>
+      </div>
+    </div>
+  </div>
+</div>`;
 
     setHtmlString(fullHtml.trim());
   };
@@ -146,9 +202,9 @@ function RecipeCard({ recipe }) {
       </button>
 
       {htmlString && (
-        <pre className="mt-4 bg-gray-100 p-2 whitespace-pre-wrap overflow-x-auto">
+        <div className="whitespace-pre-wrap bg-gray-100 p-4 mt-4">
           {htmlString}
-        </pre>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add a button to output HTML for the recipe card
- output the generated HTML block below the button
- include icon placeholders in the HTML string

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eebf119d0832699e8869d98f51190