### PR TITLE
Enable recipe card HTML export

### DIFF
--- a/src/components/RecipeCard.jsx
+++ b/src/components/RecipeCard.jsx
@@ -22,8 +22,10 @@ function RecipeCard({ recipe }) {
     const ingredientsHtml = recipe.ingredients
       .map((ing) => {
         const hasAmount = ing.amount !== undefined && ing.amount !== null && ing.amount !== '';
-        const amount = hasAmount ? Number(ing.amount) * scaleFactor : null;
-        return `<li>${hasAmount ? `${amount} ${ing.unit}` : ing.unit} ${ing.name}</li>`;
+        const amount = hasAmount ? Number(ing.amount) : null;
+        const displayAmount = hasAmount ? amount * scaleFactor : '';
+        const unit = ing.unit ? `${ing.unit} ` : '';
+        return `<li class="ingredient" data-base="${amount ?? ''}" data-unit="${ing.unit ?? ''}"><span class="quantity">${displayAmount}</span> ${unit}${ing.name}</li>`;
       })
       .join('');
 
@@ -31,76 +33,88 @@ function RecipeCard({ recipe }) {
       .map((step) => `<li>${step}</li>`)
       .join('');
 
-    const portionButtonsHtml = [1, 2, 3]
-      .map((factor) => {
-        const active = scaleFactor === factor ? 'bg-gray-300' : '';
-        return `<button class="px-2 py-1 border rounded mx-1 ${active}">${factor}x</button>`;
-      })
-      .join('');
+    const styleBlock = `<style>
+  @import url('https://fonts.googleapis.com/css2?family=Material+Icons+Outlined');
+  .receptkaart{font-family:Arial,Inter,'Segoe UI',sans-serif;max-width:700px;margin:auto;border:1px solid #ddd;padding:16px;}
+  .receptkaart .top{display:flex;justify-content:space-between;align-items:flex-start;gap:16px;}
+  .receptkaart .subtitle{font-style:italic;color:#666;}
+  .receptkaart img{width:150px;height:auto;}
+  .receptkaart .buttons{margin-top:16px;display:flex;gap:8px;}
+  .receptkaart .buttons button{padding:8px 12px;border-radius:4px;border:1px solid #ccc;background:#f2f2f2;cursor:pointer;}
+  .receptkaart .info{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px;font-size:14px;}
+  .receptkaart .info div{flex:1 1 45%;}
+  .receptkaart .scale-buttons{margin-top:16px;}
+  .receptkaart .scale-buttons button{padding:4px 8px;border:1px solid #ccc;border-radius:4px;margin-right:4px;cursor:pointer;background:#f9f9f9;}
+  .receptkaart .note-box{background:#f7f7f7;border-radius:4px;padding:12px;margin-top:16px;}
+  .receptkaart .cta{border-top:1px solid #ddd;padding-top:16px;margin-top:16px;}
+  .receptkaart .cta div{margin-bottom:4px;}
+  @media(max-width:600px){.receptkaart .top{flex-direction:column;} .receptkaart img{margin-top:12px;}}
+</style>`;
 
-    const fullHtml = `
-<div class="bg-white shadow-lg p-6 rounded-md">
-  <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center">
+    const scriptBlock = `<script>(function(){
+  const card=document.currentScript.previousElementSibling;
+  const baseServings=Number(card.dataset.baseServings);
+  const ingredients=card.querySelectorAll('.ingredient');
+  function update(f){
+    card.querySelector('.servings').textContent=(baseServings*f)+' personen';
+    ingredients.forEach(li=>{
+      const base=Number(li.dataset.base);
+      if(!isNaN(base)){
+        li.querySelector('.quantity').textContent=base*f;
+      }
+    });
+  }
+  card.querySelectorAll('.scale-buttons button').forEach(btn=>{
+    btn.addEventListener('click',()=>update(Number(btn.dataset.factor)));
+  });
+})();</script>`;
+
+    const fullHtml = `${styleBlock}
+<div class="receptkaart" data-base-servings="${recipe.servings}">
+  <div class="top">
     <div>
-      <h1 class="text-2xl font-bold">${recipe.title}</h1>
-      <h2 class="italic text-gray-600">\u2013 The Dutch Smokehouse \u2013</h2>
+      <h1>${recipe.title}</h1>
+      <h2 class="subtitle">\u2013 The Dutch Smokehouse \u2013</h2>
     </div>
-    <img src="${recipe.image}" alt="${recipe.title}" class="w-40 h-auto mt-4 sm:mt-0" />
+    <img src="${recipe.image}" alt="${recipe.title}" />
   </div>
-
-  <div class="mt-4 flex flex-wrap gap-2">
-    <button class="bg-yellow-500 text-white px-4 py-2 rounded">Recept afdrukken</button>
-    <button class="border px-4 py-2 rounded">Pin recept</button>
+  <div class="buttons">
+    <button onclick="window.print()">Recept afdrukken</button>
+    <button onclick="alert('Pin recept')">Pin recept</button>
   </div>
-
-  <div class="mt-4 grid grid-cols-2 sm:grid-cols-5 gap-y-2 text-sm">
-    <div><span class="icon icon-prep inline w-4 h-4 mr-1"></span> Voorbereiding: ${recipe.prepTime}</div>
-    <div><span class="icon icon-cook inline w-4 h-4 mr-1"></span> Bereiding: ${recipe.cookTime}</div>
-    <div><span class="icon icon-course inline w-4 h-4 mr-1"></span> Gang: ${recipe.course}</div>
-    <div><span class="icon icon-cuisine inline w-4 h-4 mr-1"></span> Keuken: ${recipe.cuisine}</div>
-    <div><span class="icon icon-servings inline w-4 h-4 mr-1"></span> Porties: ${recipe.servings * scaleFactor} personen</div>
+  <div class="info">
+    <div><span class="material-icons-outlined">schedule</span> Voorbereiding: ${recipe.prepTime}</div>
+    <div><span class="material-icons-outlined">schedule</span> Bereiding: ${recipe.cookTime}</div>
+    <div><span class="material-icons-outlined">restaurant_menu</span> Gang: ${recipe.course}</div>
+    <div><span class="material-icons-outlined">public</span> Keuken: ${recipe.cuisine}</div>
+    <div><span class="material-icons-outlined">people</span> Porties: <span class="servings">${recipe.servings * scaleFactor} personen</span></div>
   </div>
-
-  <div class="mt-4">${portionButtonsHtml}</div>
-
-  <h2 class="text-xl font-semibold mt-6 mb-2">Ingredi\u00ebnten</h2>
-  <ul class="list-disc list-inside">
+  <div class="scale-buttons">
+    <button data-factor="1">1x</button>
+    <button data-factor="2">2x</button>
+    <button data-factor="3">3x</button>
+  </div>
+  <h3>Ingredi\u00ebnten</h3>
+  <ul>
     ${ingredientsHtml}
   </ul>
-
-  <h2 class="text-xl font-semibold mt-6 mb-2">Bereiding</h2>
-  <ol class="list-decimal list-inside space-y-2">
+  <h3>Bereiding</h3>
+  <ol>
     ${instructionsHtml}
   </ol>
-
-  <div class="mt-6 border rounded p-4 bg-gray-50">
-    <h3 class="font-semibold mb-2">Notities</h3>
+  <div class="note-box">
     <p>${recipe.notes}</p>
   </div>
-
-  <details class="mt-6">
-    <summary class="cursor-pointer font-semibold">Waarom kersenhout?</summary>
-    <p class="mt-2">${recipe.woodExplanation}</p>
+  <details>
+    <summary>Waarom kersenhout?</summary>
+    <p>${recipe.woodExplanation}</p>
   </details>
-
-  <div class="mt-8 border-t pt-6">
-    <p class="text-gray-700 mb-4">
-      Deze zalm op kersenhout is perfect voor een zomerse avond, met een lichtzoete rooksmaak.
-      Maak het jezelf makkelijk en bestel de benodigdheden direct uit onze webshop.
-    </p>
-
-    <div class="space-y-2">
-      <div>
-        <span class="icon icon-cart inline w-5 h-5 mr-2 text-gray-700"></span>
-        <a href="/product/kersenhout" class="text-blue-600 underline">Kersenhout chunks voor zalm</a>
-      </div>
-      <div>
-        <span class="icon icon-cart inline w-5 h-5 mr-2 text-gray-700"></span>
-        <a href="/product/houten-rookplank" class="text-blue-600 underline">Rookplank voor visgerechten</a>
-      </div>
-    </div>
+  <div class="cta">
+    <div><span class="material-icons-outlined">shopping_cart</span> <a href="/product/kersenhout">Kersenhout chunks voor zalm</a></div>
+    <div><span class="material-icons-outlined">shopping_cart</span> <a href="/product/houten-rookplank">Rookplank voor visgerechten</a></div>
   </div>
-</div>`;
+</div>
+${scriptBlock}`;
 
     setHtmlString(fullHtml.trim());
   };
@@ -202,9 +216,7 @@ function RecipeCard({ recipe }) {
       </button>
 
       {htmlString && (
-        <div className="whitespace-pre-wrap bg-gray-100 p-4 mt-4">
-          {htmlString}
-        </div>
+        <pre className="whitespace-pre-wrap bg-gray-100 p-4 mt-4 overflow-x-auto"><code>{htmlString}</code></pre>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add HTML generator with embedded style and script for WordPress snippet
- show generated HTML as preformatted code block

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb1cfb5d88326a788a0e567573dad